### PR TITLE
fix(mac): properly handle brightness subcommand

### DIFF
--- a/functions/mac.fish
+++ b/functions/mac.fish
@@ -36,6 +36,8 @@ Options:
             __macos_mac_airdrop $argv
         case airport
             __macos_mac_airport $argv
+        case brightness
+            __macos_mac_brightness $argv
         case flushdns
             __macos_mac_flushdns $argv
         case font-smoothing


### PR DESCRIPTION
The switch statement was missing a case for the brightness subcommand, so `mac brightness up` would fail, even though the actual implementation works fine, so `__macos_mac_brightness up` would work.