### PR TITLE
feat: search for applications in more paths

### DIFF
--- a/functions/__macos_app_find.fish
+++ b/functions/__macos_app_find.fish
@@ -10,7 +10,8 @@ function __macos_app_find
 Shows installed apps by the provided pattern or patterns. Searches for
 apps in /Applications, /Applications/Setapp, /Applications/Utilities,
 ~/Applications, /Appliciations/Xcode.app/Contents/Applications,
-/Developer/Applications, and /System/Applications.
+/Developer/Applications, /System/Applications, /Applications/Nix Apps,
+and ~/Applications/Home Manager Apps.
 
 Options:
   -x, --exact             Perform exact matches only
@@ -42,7 +43,9 @@ Examples:
         /$a/Utilities \
         /$a/Xcode.app/Contents/$a \
         /Developer/Applications \
-        /System/Applications
+        /System/Applications \
+        /$a/Nix\ Apps \
+        ~/$a/Home\ Manager\ Apps
 
     set --function found 0
 


### PR DESCRIPTION
This adds the following two search paths to `app find` and every other command which depends on it (`app bundle`, etc.):

- /Applications/Nix Apps
- ~/Applications/Home Manager Apps

These are the directories in which [nix-darwin][nix-darwin] and [home-manager][home-manager] install applications.

[nix-darwin]: https://github.com/nix-darwin/nix-darwin
[home-manager]: https://github.com/nix-community/home-manager